### PR TITLE
feat : JWT 기반 인증 기능 및 인가 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,11 @@ dependencies {
 
     runtimeOnly 'com.h2database:h2'
 
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
+
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 

--- a/src/main/java/numble/instagram/api/auth/controller/AuthController.java
+++ b/src/main/java/numble/instagram/api/auth/controller/AuthController.java
@@ -1,18 +1,40 @@
-//package numble.instagram.api.auth.controller;
-//
-//import lombok.Getter;
-//import lombok.RequiredArgsConstructor;
-//import numble.instagram.api.auth.service.AuthService;
-//import org.springframework.web.bind.annotation.RequestMapping;
-//import org.springframework.web.bind.annotation.RestController;
-//
-//@Getter
-//@RequiredArgsConstructor
-//@RequestMapping("api/auth")
-//@RestController
-//public class AuthController {
-//
-//    private final AuthService authService;
-//
-//
-//}
+package numble.instagram.api.auth.controller;
+
+import jakarta.validation.Valid;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import numble.instagram.api.auth.controller.dto.request.LoginRequest;
+import numble.instagram.api.auth.controller.dto.request.ReissueTokenRequest;
+import numble.instagram.api.auth.controller.dto.response.AuthenticationResponse;
+import numble.instagram.api.auth.service.AuthService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Getter
+@RequiredArgsConstructor
+@RequestMapping("api/auth")
+@RestController
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<AuthenticationResponse> login(
+        @RequestBody @Valid LoginRequest request
+    ) {
+        AuthenticationResponse response = authService.login(request);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<AuthenticationResponse> reissue(@RequestBody @Valid final ReissueTokenRequest request) {
+        final AuthenticationResponse response = authService.reissueToken(request);
+
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/numble/instagram/api/auth/controller/dto/LoginDto.java
+++ b/src/main/java/numble/instagram/api/auth/controller/dto/LoginDto.java
@@ -1,0 +1,11 @@
+package numble.instagram.api.auth.controller.dto;
+
+import numble.instagram.domain.member.vo.Identifier;
+import numble.instagram.domain.member.vo.Password;
+
+public record LoginDto(
+    Identifier identifier,
+    Password password
+) {
+
+}

--- a/src/main/java/numble/instagram/api/auth/controller/dto/request/LoginRequest.java
+++ b/src/main/java/numble/instagram/api/auth/controller/dto/request/LoginRequest.java
@@ -1,0 +1,13 @@
+package numble.instagram.api.auth.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest (
+    @NotBlank(message = "아이디는 빈 값일 수 없습니다.")
+    String identifier,
+
+    @NotBlank(message = "비밀번호는 빈 값일 수 없습니다.")
+    String password
+){
+
+}

--- a/src/main/java/numble/instagram/api/auth/controller/dto/request/ReissueTokenRequest.java
+++ b/src/main/java/numble/instagram/api/auth/controller/dto/request/ReissueTokenRequest.java
@@ -1,0 +1,10 @@
+package numble.instagram.api.auth.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ReissueTokenRequest(
+    @NotBlank(message = "리프레시 토큰은 빈 값일 수 없습니다.")
+    String refreshToken
+) {
+
+}

--- a/src/main/java/numble/instagram/api/auth/controller/dto/response/AuthenticationResponse.java
+++ b/src/main/java/numble/instagram/api/auth/controller/dto/response/AuthenticationResponse.java
@@ -1,0 +1,8 @@
+package numble.instagram.api.auth.controller.dto.response;
+
+public record AuthenticationResponse(
+    String refreshToken,
+    String accessToken
+) {
+
+}

--- a/src/main/java/numble/instagram/api/auth/service/AuthService.java
+++ b/src/main/java/numble/instagram/api/auth/service/AuthService.java
@@ -1,21 +1,120 @@
-//package numble.instagram.api.auth.service;
-//
-//import java.util.NoSuchElementException;
-//
-//import numble.instagram.api.auth.controller.request.SignUpRequest;
-//import numble.instagram.domain.member.GenderType;
-//import numble.instagram.domain.member.Member;
-//import numble.instagram.domain.member.MemberRepository;
-//import numble.instagram.domain.member.vo.Password;
-//
-//import lombok.RequiredArgsConstructor;
-//
-//import org.springframework.stereotype.Service;
-//
-//@Service
-//@RequiredArgsConstructor
-//public class AuthService {
-//
-//    private final MemberRepository memberRepository;
-//
-//}
+package numble.instagram.api.auth.service;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import numble.instagram.api.auth.controller.dto.LoginDto;
+import numble.instagram.api.auth.controller.dto.request.LoginRequest;
+import numble.instagram.api.auth.controller.dto.request.ReissueTokenRequest;
+import numble.instagram.api.auth.controller.dto.response.AuthenticationResponse;
+import numble.instagram.api.auth.service.mapper.AuthMapper;
+import numble.instagram.common.exception.AuthenticationException;
+import numble.instagram.common.jwt.JwtTokenProvider;
+import numble.instagram.domain.auth.EncryptedToken;
+import numble.instagram.domain.auth.RefreshToken;
+import numble.instagram.domain.auth.RefreshTokenRepository;
+import numble.instagram.domain.member.Member;
+import numble.instagram.domain.member.MemberRepository;
+import numble.instagram.domain.member.vo.Password;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final MemberRepository memberRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Transactional
+    public AuthenticationResponse login(LoginRequest loginRequest) {
+        LoginDto loginDto = AuthMapper.convertToLoginDto(loginRequest);
+
+        Member member = findMember(loginDto);
+
+        checkPassword(loginDto.password(), member);
+
+        return makeAuthenticationResponse(member);
+    }
+
+    @Transactional
+    public AuthenticationResponse reissueToken(ReissueTokenRequest reissueTokenRequest) {
+        checkTokenValid(reissueTokenRequest.refreshToken());
+
+        EncryptedToken clientRefreshToken = AuthMapper.convertToEncryptedToken(reissueTokenRequest);
+        RefreshToken refreshToken = findSavedRefreshToken(clientRefreshToken);
+        checkTokenExpired(refreshToken);
+
+        refreshTokenRepository.delete(refreshToken);
+
+        Member member = refreshToken.getMember();
+
+        return makeAuthenticationResponse(member);
+    }
+
+    private void checkTokenValid(String token) {
+        if (!isCertified(token)) {
+            throw new AuthenticationException("토큰이 유효하지 않습니다.");
+        }
+    }
+
+    private RefreshToken findSavedRefreshToken(final EncryptedToken clientRefreshToken) {
+        return refreshTokenRepository.findByTokenAndIsRevokedFalse(clientRefreshToken)
+            .orElseThrow(() -> new AuthenticationException("토큰이 유효하지 않습니다."));
+    }
+
+    private void checkTokenExpired(final RefreshToken refreshToken) {
+        if (refreshToken.isExpired()) {
+            throw new AuthenticationException("토큰이 만료 되었습니다.");
+        }
+    }
+
+    public String findIdentifierByToken(final String token) {
+        return jwtTokenProvider.findSubject(token);
+    }
+
+    public boolean isCertified(String token) {
+        return jwtTokenProvider.isValidToken(token);
+    }
+
+    private Member findMember(LoginDto loginDto) {
+        return memberRepository.findByIdentifier(loginDto.identifier())
+            .orElseThrow(() -> new AuthenticationException("존재하지 않는 아이디입니다."));
+    }
+
+    private void checkPassword(Password password, Member member) {
+        if (member.isPasswordMismatch(password)) {
+
+            throw new AuthenticationException("비밀번호가 일치하지 않습니다.");
+        }
+    }
+
+    private AuthenticationResponse makeAuthenticationResponse(Member member) {
+        String refreshToken = jwtTokenProvider.createRefreshToken(
+            member.getIdentifier().getIdentifier(),
+            Map.of());
+
+        saveRefreshToken(member, refreshToken);
+
+        String accessToken = jwtTokenProvider.createAccessToken(
+            member.getIdentifier().getIdentifier(), Map.of());
+
+        return AuthMapper.convertToAuthenticationResponse(refreshToken, accessToken);
+    }
+
+    private void saveRefreshToken(Member member, String rawRefreshToken) {
+        EncryptedToken encryptedToken = new EncryptedToken(rawRefreshToken);
+
+        LocalDateTime expiredAt = jwtTokenProvider.findTokenExpiredAt(rawRefreshToken);
+
+        RefreshToken refreshToken = RefreshToken.builder()
+            .token(encryptedToken)
+            .expiredAt(expiredAt)
+            .member(member)
+            .build();
+
+        refreshTokenRepository.save(refreshToken);
+    }
+}

--- a/src/main/java/numble/instagram/api/auth/service/mapper/AuthMapper.java
+++ b/src/main/java/numble/instagram/api/auth/service/mapper/AuthMapper.java
@@ -1,0 +1,28 @@
+package numble.instagram.api.auth.service.mapper;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import numble.instagram.api.auth.controller.dto.LoginDto;
+import numble.instagram.api.auth.controller.dto.request.LoginRequest;
+import numble.instagram.api.auth.controller.dto.request.ReissueTokenRequest;
+import numble.instagram.api.auth.controller.dto.response.AuthenticationResponse;
+import numble.instagram.domain.auth.EncryptedToken;
+import numble.instagram.domain.member.vo.Identifier;
+import numble.instagram.domain.member.vo.Password;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AuthMapper {
+
+    public static LoginDto convertToLoginDto(final LoginRequest request) {
+        return new LoginDto(new Identifier(request.identifier()), new Password(request.password()));
+    }
+
+    public static AuthenticationResponse convertToAuthenticationResponse(String refreshToken, String accessToken) {
+        return new AuthenticationResponse(refreshToken, accessToken);
+    }
+
+    public static EncryptedToken convertToEncryptedToken(ReissueTokenRequest reissueTokenRequest) {
+        return new EncryptedToken(reissueTokenRequest.refreshToken());
+    }
+
+}

--- a/src/main/java/numble/instagram/api/member/controller/MemberController.java
+++ b/src/main/java/numble/instagram/api/member/controller/MemberController.java
@@ -7,8 +7,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 import numble.instagram.api.member.controller.request.MemberJoinRequest;
-import numble.instagram.api.member.service.mapper.MemberService;
 
+import numble.instagram.api.member.service.MemberService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/src/main/java/numble/instagram/api/member/service/MemberService.java
+++ b/src/main/java/numble/instagram/api/member/service/MemberService.java
@@ -1,8 +1,9 @@
-package numble.instagram.api.member.service.mapper;
+package numble.instagram.api.member.service;
 
 import lombok.RequiredArgsConstructor;
 import numble.instagram.api.member.controller.request.MemberJoinDto;
 import numble.instagram.api.member.controller.request.MemberJoinRequest;
+import numble.instagram.api.member.service.mapper.MemberMapper;
 import numble.instagram.common.exception.ConflictException;
 import numble.instagram.domain.member.Member;
 import numble.instagram.domain.member.MemberRepository;

--- a/src/main/java/numble/instagram/common/config/WebConfig.java
+++ b/src/main/java/numble/instagram/common/config/WebConfig.java
@@ -1,26 +1,28 @@
-//package numble.instagram.common.config;
-//
-//import java.util.List;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.context.annotation.Configuration;
-//import org.springframework.web.method.support.HandlerMethodArgumentResolver;
-//import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
-//import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-//
-//@Configurations
-//@RequiredArgsConstructor
-//public class WebConfig implements WebMvcConfigurer {
-//
-//    private final AuthInteceptor authInteceptor;
-//    private final MemberIdentifierArgumentResolver memberIdentifierArgumentResolver;
-//
-//    @Override
-//    public void addInterceptors(InterceptorRegistry interceptorRegistry) {
-//        interceptorRegistry.addInterceptor(authInteceptor);
-//    }
-//
-//    @Override
-//    public void addInterceptors(List<HandlerMethodArgumentResolver> argumentResolvers) {
-//        argumentResolvers.add(memberIdentifierArgumentResolver);
-//    }
-//}
+package numble.instagram.common.config;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import numble.instagram.common.interceptor.AuthInterceptor;
+import numble.instagram.common.resolver.MemberIdentifierArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthInterceptor authInteceptor;
+    private final MemberIdentifierArgumentResolver memberIdentifierArgumentResolver;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry interceptorRegistry) {
+        interceptorRegistry.addInterceptor(authInteceptor);
+    }
+
+    @Override
+    public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(memberIdentifierArgumentResolver);
+    }
+}

--- a/src/main/java/numble/instagram/common/exception/AuthenticationException.java
+++ b/src/main/java/numble/instagram/common/exception/AuthenticationException.java
@@ -1,0 +1,8 @@
+package numble.instagram.common.exception;
+
+public class AuthenticationException extends RuntimeException {
+
+    public AuthenticationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/numble/instagram/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/numble/instagram/common/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -31,13 +32,30 @@ public class GlobalExceptionHandler {
             .body(ErrorResponse.of(getMessage(exception)));
     }
 
-    @ExceptionHandler({Exception.class, RuntimeException.class})
-    public ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException exception) {
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception exception) {
+        log.error("Unexpected Error occurred: {}", exception.getMessage(), exception);
+
+        return ResponseEntity.internalServerError()
+            .body(ErrorResponse.of(getMessage(exception)));
+    }
+
+    @ExceptionHandler(ServerException.class)
+    public ResponseEntity<ErrorResponse> handleServerException(ServerException exception) {
         log.error("Server Error occurred: {}", exception.getMessage(), exception);
 
         return ResponseEntity.internalServerError()
             .body(ErrorResponse.of(getMessage(exception)));
     }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ErrorResponse> handleAuthenticationException(final AuthenticationException exception) {
+        log.warn(exception.getMessage(), exception);
+
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+            .body(ErrorResponse.of(getMessage(exception)));
+    }
+
 
     private String getMessage(Exception e) {
         return Optional.ofNullable(e.getCause())

--- a/src/main/java/numble/instagram/common/interceptor/AuthInterceptor.java
+++ b/src/main/java/numble/instagram/common/interceptor/AuthInterceptor.java
@@ -1,49 +1,48 @@
-//package numble.instagram.common.interceptor;
-//
-//import jakarta.servlet.http.HttpServletRequest;
-//import jakarta.servlet.http.HttpServletResponse;
-//import java.net.http.HttpHeaders;
-//import numble.instagram.api.auth.service.AuthService;
-//import org.springframework.web.servlet.HandlerInterceptor;
-//
-//public class AuthInterceptor implements HandlerInterceptor {
-//
-//    private static final String BEARER_PREFIX = "Bearer ";
-//
-//    private final AuthService authService;
-//
-//    @Override
-//    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object Handler) {
-//        if (handlerMethod.hasMethodAnnotation(Authenticated.class)) {
-//            String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
-//            checkHeader(authorizationHeader);
-//
-//            String token = authorizationHeader.substring(BEARER_PREFIX.length());
-//
-//            checkTokenCertify(token);
-//        }
-//
-//        return true;
-//    }
-//
-//    private void checkHeader(String authorizationHeader) {
-//        if (authorizationHeader == null || !authorizationHeader.startsWith(BEARER_PREFIX)) {
-//            throw new AuthenticationException("인증 헤더가 적절하지 않습니다.");
-//        }
-//    }
-//
-//    private void checkTokenVerify(String token) {
-//        if (!authService.isCertified(token)) {
-//            throw new AuthenticationException("토큰이 유효하지 않습니다.");
-//        }
-//    }
-//}
+package numble.instagram.common.interceptor;
 
-//    @ExceptionHandler(AuthenticationException.class)
-//    public ResponseEntity<ErrorResponse> handleAuthenticationException(AuthenticationException exception) {
-//        log.debug("Authentication error occurred: {}", exception.getMessage(), exception);
-//
-//        ErrorResponse errorResponse = ErrorResponse.of(exception.getMessage());
-//
-//        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
-//    }
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import lombok.RequiredArgsConstructor;
+import numble.instagram.api.auth.service.AuthService;
+
+import numble.instagram.common.exception.AuthenticationException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@RequiredArgsConstructor
+public class AuthInterceptor implements HandlerInterceptor {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final AuthService authService;
+
+    @Override
+    public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler) {
+        if (!(handler instanceof final HandlerMethod handlerMethod)) {
+            return true;
+        }
+        if (handlerMethod.hasMethodAnnotation(Authenticated.class)) {
+            final String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+            checkHeader(authorizationHeader);
+            final String token = authorizationHeader.substring(BEARER_PREFIX.length());
+            checkTokenCertify(token);
+        }
+        return true;
+    }
+
+    private void checkHeader(String authorizationHeader) {
+        if (authorizationHeader == null || !authorizationHeader.startsWith(BEARER_PREFIX)) {
+            throw new AuthenticationException("인증 헤더가 적절하지 않습니다.");
+        }
+    }
+
+    private void checkTokenCertify(String token) {
+        if (!authService.isCertified(token)) {
+            throw new AuthenticationException("토큰이 유효하지 않습니다.");
+        }
+    }
+}

--- a/src/main/java/numble/instagram/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/numble/instagram/common/jwt/JwtTokenProvider.java
@@ -1,168 +1,99 @@
-//package numble.instagram.common.jwt;
-//
-//import jakarta.annotation.PostConstruct;
-//import jakarta.servlet.http.HttpServletRequest;
-//import jakarta.servlet.http.HttpServletResponse;
-//import java.nio.charset.StandardCharsets;
-//import java.security.Key;
-//import java.util.Calendar;
-//import java.util.Date;
-//import java.util.HashMap;
-//import java.util.Map;
-//import lombok.Getter;
-//import lombok.Value;
-//import lombok.extern.slf4j.Slf4j;
-//import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-//import org.springframework.security.core.Authentication;
-//import org.springframework.stereotype.Component;
-//import org.springframework.util.StringUtils;
-//
-//@Slf4j
-//@Component
-//public class JwtTokenProvider {
-//
-//    public static final String BEARER_TYPE = "Bearer";
-//    public static final String AUTHORIZATION_HEADER = "Authorization";
-//    public static final String REFRESH_TOKEN_HEADER = "Refresh";
-//    public static final String BEARER_PREFIX = "Bearer ";
-//
-//    @Getter
-//    @Value("${jwt.secret-key}")
-//    private String secretKey;
-//
-//    @Getter
-//    @Value("${jwt.access-token-expiration-millis}")
-//    private long accessTokenExpirationMillis;
-//
-//    @Getter
-//    @Value("${jwt.refresh-token-expiration-millis}")
-//    private long refreshTokenExpirationMillis;
-//
-//    private Key key;
-//
-//    @PostConstruct
-//    public void init() {
-//        String base64EncodedSecretKey = encodeBase64SecretKey(this.secretKey);
-//        this.key = getKeyFromBase64EncodedKey(base64EncodedSecretKey);
-//    }
-//
-//    public String encodeBase64SecretKey(String secretKey) {
-//        return Encoders.BASE64.encode(secretKey.getBytes(StandardCharsets.UTF_8));
-//    }
-//
-//    private Key getKeyFromBase64EncodedKey(String base64EncodedSecretKey) {
-//        byte[] keyBytes = Decoders.BASE64.decode(base64EncodedSecretKey);
-//        return Keys.hmacShaKeyFor(keyBytes);
-//    }
-//
-//    public TokenDto generateTokenDto(CustomUserDetails customUserDetails) {
-//        Date accessTokenExpiresIn = getTokenExpiration(accessTokenExpirationMillis);
-//        Date refreshTokenExpiresIn = getTokenExpiration(refreshTokenExpirationMillis);
-//
-//        Map<String, Object> claims = new HashMap<>();
-//        claims.put("role", customUserDetails.getRole());
-//
-//        String accessToken = Jwts.builder()
-//            .setClaims(claims)
-//            .setSubject(customUserDetails.getEmail())
-//            .setExpiration(accessTokenExpiresIn)
-//            .setIssuedAt(Calendar.getInstance().getTime())
-//            .signWith(key, SignatureAlgorithm.HS256)
-//            .compact();
-//
-//        String refreshToken = Jwts.builder()
-//            .setClaims(claims)
-//            .setSubject(customUserDetails.getEmail())
-//            .setExpiration(accessTokenExpiresIn)
-//            .setIssuedAt(Calendar.getInstance().getTime())
-//            .signWith(key, SignatureAlgorithm.HS256)
-//            .compact();
-//
-//        return TokenDto.builder()
-//            .grantType(BEARER_TYPE)
-//            .authorizationType(AUTHORIZATION_HEADER)
-//            .accessToken(accessToken)
-//            .accessTokenExpiresIn(accessTokenExpiresIn.getTime())
-//            .refreshToken(refreshToken)
-//            .build();
-//    }
-//
-//    public Authentication getAuthentication(String accessToken) {
-//        Claims claims = parseClaims(accessToken);
-//
-//        if (claims.get("role") == null) {
-//            throw new Exception("액세스 토큰이 존재하지 않습니다.");
-//        }
-//
-//        String authority = claims.get("role").toString();
-//
-//        CustomUserDetails.of(claims.getSubject(), authority);
-//
-//        return new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
-//    }
-//
-//    public boolean validateToken(String token, HttpServletResponse response) {
-//        try {
-//            parseClaims(token);
-//        } catch (MalformedJwtException e) {
-//            log.info("Invalid JWT token");
-//            log.trace("Invalid JWT token trace = {}", e);
-//        } catch (ExpiredJwtException e) {
-//            log.info("Expired JWT token");
-//            log.trace("Expired JWT token trace = {}", e);
-//            Responder.sendErrorResponse(response, ExceptionCode.TOKEN_EXPIRED);
-//        } catch (UnsupportedJwtException e) {
-//            log.info("Unsupported JWT token");
-//            log.trace("Unsupported JWT token trace = {}", e);
-//            Responder.sendErrorResponse(response, ExceptionCode.TOKEN_UNSUPPORTED);
-//        } catch (IllegalArgumentException e) {
-//            log.info("JWT claims string is empty.");
-//            log.trace("JWT claims string is empty trace = {}", e);
-//            Responder.sendErrorResponse(response, ExceptionCode.TOKEN_ILLEGAL_ARGUMENT);
-//        }
-//        return true;
-//    }
-//
-//    private Date getTokenExpiration(long expirationMillisecond) {
-//        Date date = new Date();
-//
-//        return new Date(date.getTime() + expirationMillisecond);
-//    }
-//
-//    // Token 복호화 및 예외 발생(토큰 만료, 시그니처 오류)시 Claims 객체가 안만들어짐.
-//    public Claims parseClaims(String token) {
-//        return Jwts.parserBuilder()
-//            .setSigningKey(key)
-//            .build()
-//            .parseClaimsJws(token)
-//            .getBody();
-//    }
-//
-//    public void accessTokenSetHeader(String accessToken, HttpServletResponse response) {
-//        String headerValue = BEARER_PREFIX + accessToken;
-//        response.setHeader(AUTHORIZATION_HEADER, headerValue);
-//    }
-//
-//    public void refresshTokenSetHeader(String refreshToken, HttpServletResponse response) {
-//        response.setHeader("Refresh", refreshToken);
-//    }
-//
-//    // Request Header에 Access Token 정보를 추출
-//    public String resolveAccessToken(HttpServletRequest request) {
-//        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
-//        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
-//            return bearerToken.substring(7);
-//        }
-//        return null;
-//    }
-//
-//    // Request Header에 Refresh Token 정보를 추출
-//    public String resolveRefreshToken(HttpServletRequest request) {
-//        String bearerToken = request.getHeader(REFRESH_TOKEN_HEADER);
-//        if (StringUtils.hasText(bearerToken)) {
-//            return bearerToken;
-//        }
-//        return null;
-//    }
-//
-//}
+package numble.instagram.common.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.Map;
+import javax.crypto.SecretKey;
+import numble.instagram.common.exception.AuthenticationException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider  {
+
+    private final String secretKey;
+    private final Long accessTokenValidityInSeconds;
+    private final Long refreshTokenValidityInSeconds;
+
+    public JwtTokenProvider(@Value("${jwt.secret-key}") final String secretKey,
+        @Value("#{T(Long).parseLong('${jwt.access-token-validity-in-seconds}')}") final Long accessTokenValidityInSeconds,
+        @Value("#{T(Long).parseLong('${jwt.refresh-token-validity-in-seconds}')}") final Long refreshTokenValidityInSeconds) {
+        this.secretKey = secretKey;
+        this.accessTokenValidityInSeconds = accessTokenValidityInSeconds;
+        this.refreshTokenValidityInSeconds = refreshTokenValidityInSeconds;
+    }
+
+    public String createAccessToken(final String subject, final Map<String, Object> claims) {
+        return createToken(accessTokenValidityInSeconds, subject, claims);
+    }
+
+    public String createRefreshToken(final String subject, final Map<String, Object> claims) {
+        return createToken(refreshTokenValidityInSeconds, subject, claims);
+    }
+
+    private String createToken(final Long tokenValidityInSeconds, final String subject, final Map<String, Object> claims) {
+        SecretKey signingKey = createKey();
+        Date expiration = createExpiration(tokenValidityInSeconds);
+
+        return Jwts.builder()
+            .signWith(signingKey)
+            .setClaims(claims)
+            .setSubject(subject)
+            .setExpiration(expiration)
+            .compact();
+    }
+
+    private SecretKey createKey() {
+        byte[] secretKeyBytes = secretKey.getBytes(StandardCharsets.UTF_8);
+        return Keys.hmacShaKeyFor(secretKeyBytes);
+    }
+
+    private Date createExpiration(final Long validity) {
+        long now = new Date().getTime();
+        return new Date(now + validity);
+    }
+
+    public boolean isValidToken(final String token) {
+        try {
+            parseToClaimsJws(token);
+        } catch (final ExpiredJwtException expiredJwtException) {
+            throw new AuthenticationException("Expired Token");
+        } catch (final JwtException jwtException) {
+            throw new AuthenticationException("Invalid Token");
+        }
+        return true;
+    }
+
+    private Jws<Claims> parseToClaimsJws(final String token) {
+        SecretKey signingKey = createKey();
+
+        return Jwts.parserBuilder()
+            .setSigningKey(signingKey)
+            .build()
+            .parseClaimsJws(token);
+    }
+
+    public LocalDateTime findTokenExpiredAt(final String token) {
+        Jws<Claims> claimsJws = parseToClaimsJws(token);
+        Date expiration = claimsJws.getBody()
+            .getExpiration();
+
+        return expiration.toInstant()
+            .atZone(ZoneId.systemDefault())
+            .toLocalDateTime();
+    }
+
+    public String findSubject(final String token) {
+        Jws<Claims> claimsJws = parseToClaimsJws(token);
+        return claimsJws.getBody()
+            .getSubject();
+    }
+}

--- a/src/main/java/numble/instagram/common/resolver/MemberIdentifierArgumentResolver.java
+++ b/src/main/java/numble/instagram/common/resolver/MemberIdentifierArgumentResolver.java
@@ -1,44 +1,44 @@
-//package numble.instagram.common.resolver;
-//
-//import java.net.http.HttpHeaders;
-//import javax.naming.AuthenticationException;
-//import lombok.RequiredArgsConstructor;
-//import numble.instagram.api.auth.service.AuthService;
-//import numble.instagram.common.interceptor.MemberIdentifier;
-//import org.springframework.core.MethodParameter;
-//import org.springframework.stereotype.Component;
-//import org.springframework.web.bind.support.WebDataBinderFactory;
-//import org.springframework.web.context.request.NativeWebRequest;
-//import org.springframework.web.method.support.HandlerMethodArgumentResolver;
-//import org.springframework.web.method.support.ModelAndViewContainer;
-//
-//@Component
-//@RequiredArgsConstructor
-//public class MemberIdentifierArgumentResolver implements HandlerMethodArgumentResolver {
-//
-//    private static final String BEARER_PREFIX = "Bearer ";
-//    private final AuthService authService;
-//
-//    @Override
-//    public boolean supportsParameter(MethodParameter parameter) {
-//        return parameter.hasParameterAnnotation(MemberIdentifier.class);
-//    }
-//
-//    @Override
-//    public String resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
-//        NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
-//
-//        final String authorizationHeader = webRequest.getHeader(HttpHeaders.AUTHORIZATION);
-//
-//        checkHeader(authorizationHeader);
-//
-//        String token = authorizationHeader.substring(BEARER_PREFIX.length());
-//        return authService.findIdentifierByToken(token);
-//    }
-//
-//    private void checkHeader(final String authorizationHeader) {
-//        if (authorizationHeader == null || !authorizationHeader.startsWith(BEARER_PREFIX)) {
-//            throw new AuthenticationException("인증 헤더가 적절하지 않습니다.");
-//        }
-//    }
-//}
+package numble.instagram.common.resolver;
+
+import lombok.RequiredArgsConstructor;
+import numble.instagram.api.auth.service.AuthService;
+import numble.instagram.common.exception.AuthenticationException;
+import numble.instagram.common.interceptor.MemberIdentifier;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class MemberIdentifierArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+    private final AuthService authService;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(MemberIdentifier.class);
+    }
+
+    @Override
+    public String resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+
+        final String authorizationHeader = webRequest.getHeader(HttpHeaders.AUTHORIZATION);
+
+        checkHeader(authorizationHeader);
+
+        String token = authorizationHeader.substring(BEARER_PREFIX.length());
+        return authService.findIdentifierByToken(token);
+    }
+
+    private void checkHeader(final String authorizationHeader) {
+        if (authorizationHeader == null || !authorizationHeader.startsWith(BEARER_PREFIX)) {
+            throw new AuthenticationException("인증 헤더가 적절하지 않습니다.");
+        }
+    }
+}

--- a/src/main/java/numble/instagram/domain/auth/EncryptedToken.java
+++ b/src/main/java/numble/instagram/domain/auth/EncryptedToken.java
@@ -1,0 +1,58 @@
+package numble.instagram.domain.auth;
+
+import jakarta.persistence.Column;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import numble.instagram.common.exception.ServerException;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EncryptedToken {
+    private static final String ALGORITHM = "SHA-256";
+
+    @Column(name = "token", nullable = false)
+    private String value;
+
+    public EncryptedToken(String token) {
+        this.value = encrypt(token);
+    }
+
+    private String encrypt(String token) {
+        MessageDigest messageDigest = findMessageDigest();
+        messageDigest.update(token.getBytes());
+
+        byte[] tokenHash = messageDigest.digest();
+
+        return Base64.getEncoder().encodeToString(tokenHash);
+    }
+
+    private MessageDigest findMessageDigest() {
+        try {
+            return MessageDigest.getInstance(ALGORITHM);
+        } catch (NoSuchAlgorithmException exception) {
+            throw new ServerException("존재하지 않는 알고리즘입니다.");
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        EncryptedToken that = (EncryptedToken) o;
+        return Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+}

--- a/src/main/java/numble/instagram/domain/auth/RefreshToken.java
+++ b/src/main/java/numble/instagram/domain/auth/RefreshToken.java
@@ -1,0 +1,53 @@
+package numble.instagram.domain.auth;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import numble.instagram.domain.member.Member;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Embedded
+    private EncryptedToken token;
+
+    @Column(nullable = false)
+    private boolean isRevoked = false;
+
+    @Column(nullable = false)
+    private LocalDateTime expiredAt;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Builder
+    public RefreshToken(EncryptedToken token, LocalDateTime expiredAt, Member member) {
+        this.token = token;
+        this.expiredAt = expiredAt;
+        this.member = member;
+    }
+
+    public boolean isExpired() {
+        return expiredAt.isBefore(LocalDateTime.now());
+    }
+}

--- a/src/main/java/numble/instagram/domain/auth/RefreshTokenRepository.java
+++ b/src/main/java/numble/instagram/domain/auth/RefreshTokenRepository.java
@@ -1,0 +1,14 @@
+package numble.instagram.domain.auth;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    @Query("SELECT rt FROM RefreshToken rt JOIN FETCH rt.member m where rt.token= :token AND rt.isRevoked = false")
+    Optional<RefreshToken> findByTokenAndIsRevokedFalse(final EncryptedToken token);
+
+}

--- a/src/main/java/numble/instagram/domain/member/Member.java
+++ b/src/main/java/numble/instagram/domain/member/Member.java
@@ -16,6 +16,7 @@ import lombok.NoArgsConstructor;
 import numble.instagram.common.entity.TimeBaseEntity;
 import numble.instagram.domain.member.vo.EncodedPassword;
 import numble.instagram.domain.member.vo.Identifier;
+import numble.instagram.domain.member.vo.Password;
 import numble.instagram.domain.memberprofile.MemberProfile;
 
 @Getter
@@ -42,5 +43,9 @@ public class Member extends TimeBaseEntity {
         this.identifier = identifier;
         this.password = password;
         this.memberProfile = memberProfile;
+    }
+
+    public boolean isPasswordMismatch(Password password) {
+        return this.password.isMismatch(password);
     }
 }

--- a/src/main/java/numble/instagram/domain/member/MemberRepository.java
+++ b/src/main/java/numble/instagram/domain/member/MemberRepository.java
@@ -1,6 +1,5 @@
 package numble.instagram.domain.member;
 
-import jakarta.persistence.Id;
 import java.util.Optional;
 import numble.instagram.domain.member.vo.Identifier;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/numble/instagram/domain/member/vo/EncodedPassword.java
+++ b/src/main/java/numble/instagram/domain/member/vo/EncodedPassword.java
@@ -22,12 +22,8 @@ public class EncodedPassword {
     private String salt;
 
     public EncodedPassword(Password rawPassword) {
-        try {
-            this.salt = generateSalt(rawPassword.length());
-            this.password = encode(rawPassword, salt);
-        } catch (NoSuchAlgorithmException exception) {
-            throw new ServerException(exception.getMessage());
-        }
+        this.salt = generateSalt(rawPassword.length());
+        this.password = encode(rawPassword, salt);
     }
 
     private String generateSalt(int length) {
@@ -37,8 +33,8 @@ public class EncodedPassword {
         return Base64.getEncoder().encodeToString(value);
     }
 
-    private String encode(Password password, String salt) throws NoSuchAlgorithmException {
-        MessageDigest messageDigest = MessageDigest.getInstance(ALGORITHM);
+    private String encode(Password password, String salt) {
+        MessageDigest messageDigest = findMessageDigest();
         messageDigest.update(salt.getBytes());
 
         messageDigest.update(password.getBytes());
@@ -47,6 +43,19 @@ public class EncodedPassword {
 
         return Base64.getEncoder().encodeToString(hashPassword);
 
+    }
+
+    private MessageDigest findMessageDigest() {
+        try {
+            return MessageDigest.getInstance(ALGORITHM);
+        } catch (NoSuchAlgorithmException exception) {
+            throw new ServerException("존재하지 않는 알고리즘입니다.");
+        }
+    }
+
+    public boolean isMismatch(final Password password) {
+        final String encrypted = encode(password, this.salt);
+        return !encrypted.equals(this.password);
     }
 
     @Override

--- a/src/main/java/numble/instagram/domain/member/vo/Identifier.java
+++ b/src/main/java/numble/instagram/domain/member/vo/Identifier.java
@@ -3,9 +3,11 @@ package numble.instagram.domain.member.vo;
 import jakarta.persistence.Column;
 import java.util.Objects;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class Identifier {
 
     private static final int MIN_LENGTH = 6;

--- a/src/main/java/numble/instagram/domain/member/vo/Password.java
+++ b/src/main/java/numble/instagram/domain/member/vo/Password.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import numble.instagram.common.exception.AuthenticationException;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -54,7 +55,7 @@ public class Password {
 
     private void validatePassword(String password) {
         if (isNotValidLength(password) || isNotValidPattern(password)) {
-            throw new IllegalArgumentException("제약 조건에 맞지 않는 비밀번호입니다.");
+            throw new AuthenticationException("제약 조건에 맞지 않는 비밀번호입니다.");
         }
     }
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,7 +4,7 @@ spring:
       on-profile: local
 
   datasource:
-    url: jdbc:h2:~/insta
+    url: jdbc:h2:tcp://localhost/~/insta
     driver-class-name: org.h2.Driver
     username: sa
     password:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,7 +4,7 @@ spring:
       on-profile: local
 
   datasource:
-    url: jdbc:h2:tcp://localhost/~/insta
+    url: jdbc:h2:~/instagram
     driver-class-name: org.h2.Driver
     username: sa
     password:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,7 +4,7 @@ spring:
       on-profile: local
 
   datasource:
-    url: jdbc:h2:~/projects/instagram
+    url: jdbc:h2:~/insta
     driver-class-name: org.h2.Driver
     username: sa
     password:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -4,7 +4,7 @@ spring:
       on-profile: test
 
   datasource:
-    url: jdbc:h2:~/insta
+    url: jdbc:h2:tcp://localhost/~/insta
     driver-class-name: org.h2.Driver
     username: sa
     password:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -4,7 +4,7 @@ spring:
       on-profile: test
 
   datasource:
-    url: jdbc:h2:tcp://localhost/~/insta
+    url: jdbc:h2:~/instagram
     driver-class-name: org.h2.Driver
     username: sa
     password:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -4,7 +4,7 @@ spring:
       on-profile: test
 
   datasource:
-    url: jdbc:h2:~/projects/instagram
+    url: jdbc:h2:~/insta
     driver-class-name: org.h2.Driver
     username: sa
     password:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,3 +16,8 @@ spring:
       ddl-auto: none
     database: mysql
     database-platform: org.hibernate.dialect.H2Dialect
+
+jwt:
+  secret-key: adminjsdfjj9o2184uoi8eur302udshfjnsadjfhjsdbfi0238u40hasdfjhk4!
+  access-token-validity-in-seconds: 10800
+  refresh-token-validity-in-seconds: 86400

--- a/src/test/java/numble/instagram/spring/api/auth/service/AuthServiceTest.java
+++ b/src/test/java/numble/instagram/spring/api/auth/service/AuthServiceTest.java
@@ -1,0 +1,222 @@
+package numble.instagram.spring.api.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import numble.instagram.api.auth.controller.dto.request.LoginRequest;
+import numble.instagram.api.auth.controller.dto.request.ReissueTokenRequest;
+import numble.instagram.api.auth.controller.dto.response.AuthenticationResponse;
+import numble.instagram.api.auth.service.AuthService;
+import numble.instagram.common.exception.AuthenticationException;
+import numble.instagram.common.jwt.JwtTokenProvider;
+import numble.instagram.domain.auth.EncryptedToken;
+import numble.instagram.domain.auth.RefreshToken;
+import numble.instagram.domain.auth.RefreshTokenRepository;
+import numble.instagram.domain.member.GenderType;
+import numble.instagram.domain.member.Member;
+import numble.instagram.domain.member.MemberRepository;
+import numble.instagram.domain.member.vo.EncodedPassword;
+import numble.instagram.domain.member.vo.Identifier;
+import numble.instagram.domain.member.vo.Password;
+import numble.instagram.domain.memberprofile.MemberProfile;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties.Lettuce.Cluster.Refresh;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthServiceTest {
+
+    private static Member member;
+    private static MemberProfile memberProfile;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @InjectMocks
+    private AuthService authService;
+
+    @BeforeAll
+    static void setUp() {
+        memberProfile = createMemberProfile(
+            "test@gmail.com",
+            "insta",
+            "nickname",
+            GenderType.MAN,
+            "010-1234-5678"
+        );
+
+        member = createMember(
+            new Identifier("identifier1"),
+            new Password("password1"),
+            memberProfile
+        );
+    }
+
+    @DisplayName("로그인에 성공한다.")
+    @Test
+    void loginSuccess() {
+        // given
+        LoginRequest loginRequest = new LoginRequest("identifier1", "password1");
+        String accessToken = "accessToken";
+        String refreshToken = "refreshToken";
+
+        given(memberRepository.findByIdentifier(any()))
+            .willReturn(Optional.of(member));
+
+        given(jwtTokenProvider.createAccessToken(any(), any()))
+            .willReturn(accessToken);
+
+        given(jwtTokenProvider.createRefreshToken(any(), any()))
+            .willReturn(refreshToken);
+
+        given(jwtTokenProvider.findTokenExpiredAt(anyString()))
+            .willReturn(LocalDateTime.now());
+
+        // when
+        AuthenticationResponse authenticationResponse = authService.login(loginRequest);
+
+        // then
+        assertThat(authenticationResponse.accessToken()).isEqualTo(accessToken);
+        assertThat(authenticationResponse.refreshToken()).isEqualTo(refreshToken);
+    }
+
+    @DisplayName("존재하지 않는 아이디로 로그인 시, 예외가 발생한다.")
+    @Test
+    void loginWithNotExistIdentifier() {
+        // given
+        final LoginRequest loginRequest = new LoginRequest("identifier1", "password1!");
+
+        given(memberRepository.findByIdentifier(any()))
+            .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> authService.login(loginRequest))
+            .isInstanceOf(AuthenticationException.class)
+            .hasMessage("존재하지 않는 아이디입니다.");
+    }
+
+    @DisplayName("유효하지 않은 비밀번호로 로그인 시, 예외가 발생한다.")
+    @Test
+    void loginWithInvalidPassword() {
+        // given
+        final LoginRequest loginRequest = new LoginRequest("identifier1", "illegal");
+
+        // when & then
+        assertThatThrownBy(() -> authService.login(loginRequest))
+            .isInstanceOf(AuthenticationException.class)
+            .hasMessage("제약 조건에 맞지 않는 비밀번호입니다.");
+    }
+
+    @DisplayName("Refresh Token을 정상적으로 재 발급한다.")
+    @Test
+    void reissueToken() {
+        // given
+        String rawRefreshToken = "refreshToken";
+
+        ReissueTokenRequest request = new ReissueTokenRequest("refreshToken");
+
+        RefreshToken refreshToken = new RefreshToken(new EncryptedToken(rawRefreshToken),
+            LocalDateTime.MAX, member);
+
+        given(jwtTokenProvider.isValidToken(any()))
+            .willReturn(true);
+
+        given(refreshTokenRepository.findByTokenAndIsRevokedFalse(any()))
+            .willReturn(Optional.of(refreshToken));
+
+        given(jwtTokenProvider.createRefreshToken(any(), any()))
+            .willReturn(rawRefreshToken);
+
+        given(jwtTokenProvider.findTokenExpiredAt(anyString()))
+            .willReturn(LocalDateTime.now());
+
+        // when
+        AuthenticationResponse authenticationResponse = authService.reissueToken(request);
+
+        // then
+        assertThat(authenticationResponse.refreshToken()).isEqualTo(rawRefreshToken);
+    }
+
+    @DisplayName("리프레시 토큰이 유효하지 않을 경우, 예외가 발생한다.")
+    @Test
+    void invalidRefreshToken() {
+        // given
+        String rawRefreshToken = "refreshToken";
+        ReissueTokenRequest request = new ReissueTokenRequest(rawRefreshToken);
+
+        given(jwtTokenProvider.isValidToken(any()))
+            .willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> authService.reissueToken(request))
+            .isInstanceOf(AuthenticationException.class);
+    }
+
+    @DisplayName("리프레시 토큰이 만료된 경우, 예외가 발생한다.")
+    @Test
+    void timeoutRefreshToken() {
+        // given
+        String rawRefreshToken = "refreshToken";
+        ReissueTokenRequest request = new ReissueTokenRequest(rawRefreshToken);
+        RefreshToken refreshToken = new RefreshToken(new EncryptedToken(rawRefreshToken), LocalDateTime.MIN, member);
+
+
+        given(jwtTokenProvider.isValidToken(any()))
+            .willReturn(true);
+
+        given(refreshTokenRepository.findByTokenAndIsRevokedFalse(any()))
+            .willReturn(Optional.of(refreshToken));
+
+        // when & then
+        assertThatThrownBy(() -> authService.reissueToken(request))
+            .isInstanceOf(AuthenticationException.class);
+    }
+
+    private static MemberProfile createMemberProfile(
+        String email,
+        String nickname,
+        String name,
+        GenderType genderType,
+        String phoneNumber
+    ) {
+
+        return MemberProfile.builder()
+            .email(email)
+            .nickname(nickname)
+            .name(name)
+            .genderType(genderType)
+            .phoneNumber(phoneNumber)
+            .build();
+    }
+
+    private static Member createMember(
+        Identifier identifier,
+        Password password,
+        MemberProfile memberProfile
+    ) {
+
+        EncodedPassword encodedPassword = new EncodedPassword(password);
+
+        return Member.builder()
+            .identifier(identifier)
+            .password(encodedPassword)
+            .memberProfile(memberProfile)
+            .build();
+    }
+}

--- a/src/test/java/numble/instagram/spring/api/auth/service/JwtTokenProviderTest.java
+++ b/src/test/java/numble/instagram/spring/api/auth/service/JwtTokenProviderTest.java
@@ -1,0 +1,141 @@
+package numble.instagram.spring.api.auth.service;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.util.HashMap;
+import java.util.Map;
+import numble.instagram.common.exception.AuthenticationException;
+import numble.instagram.common.jwt.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class JwtTokenProviderTest {
+
+    private static final String secretKey = "adminjsdfjj9o2184uoi8eur302udshfjnsadjfhjsdbfi0238u40hasdfjhk4!";
+
+    JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(secretKey, 1_080_000L, 8_640_000L);
+
+    @BeforeAll
+    static void beforeAll() {
+        final String subject = "subject";
+        final Map<String, Object> claims = new HashMap<>
+            (Map.of("test1", "test1", "test2", "test2"));
+    }
+
+
+    @DisplayName("subject, claims를 포함한 ACCESS TOKEN을 정상적으로 생성한다.")
+    @Test
+    void createAccessToken() {
+        // given
+        final String subject = "subject";
+        final Map<String, Object> claims = new HashMap<>
+            (Map.of("test1", "test1", "test2", "test2"));
+
+        // when
+        String accessToken = jwtTokenProvider.createAccessToken(subject, claims);
+        Claims result = getClaims(accessToken);
+
+        // then
+
+        assertThat(result.getSubject()).isEqualTo(subject);
+
+        for (String claimKey : claims.keySet()) {
+            String claim = result.get(claimKey, String.class);
+            assertThat(claim).isEqualTo(claims.get(claimKey));
+        }
+
+        assertThatCode(result::getExpiration)
+            .doesNotThrowAnyException();
+
+    }
+
+    @DisplayName("subject, claims를 포함한 REFRESH TOKEN을 정상적으로 생성한다.")
+    @Test
+    void createRefreshToken() {
+        // given
+        final String subject = "subject";
+        final Map<String, Object> claims = new HashMap<>
+            (Map.of("test1", "test1", "test2", "test2"));
+
+        // when
+        String refreshToken = jwtTokenProvider.createRefreshToken(subject, claims);
+
+        // then
+        Claims result = getClaims(refreshToken);
+
+        assertThat(result.getSubject()).isEqualTo(subject);
+
+        for (String claimKey : claims.keySet()) {
+            String claim = result.get(claimKey, String.class);
+        }
+
+        assertDoesNotThrow(result::getExpiration);
+    }
+
+    @DisplayName("만료된 토큰의 경우, 유효성 검사에서 에러를 발생시킨다.")
+    @Test
+    void isValidTokenWithExpiredToken() {
+        // given
+        final String subject = "subject";
+        final Map<String, Object> claims = new HashMap<>
+            (Map.of("test1", "test1", "test2", "test2"));
+
+        JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(secretKey, 0L, 0L);
+        String accessToken = jwtTokenProvider.createAccessToken(subject, claims);
+
+        // when & then
+        assertThatThrownBy(() -> jwtTokenProvider.isValidToken(accessToken))
+            .isInstanceOf(AuthenticationException.class)
+            .hasMessage("Expired Token");
+    }
+
+    @DisplayName("유효하지 않은 토큰을 사용하는 경우, 에러를 발생시킨다.")
+    @Test
+    void isValidTokenWithInvalidToken() {
+        // given
+        String accessToken = "invalid";
+
+        // when & then
+        assertThatThrownBy(() -> jwtTokenProvider.isValidToken(accessToken))
+            .isInstanceOf(AuthenticationException.class)
+            .hasMessage("Invalid Token");
+    }
+
+    @DisplayName("토큰을 통해 subject를 가져온다.")
+    @Test
+    void findSubject() {
+        // given
+        final String subject = "subject";
+        final Map<String, Object> claims = new HashMap<>
+            (Map.of("test1", "test1", "test2", "test2"));
+
+        String accessToken = jwtTokenProvider.createAccessToken(subject, claims);
+
+        // when
+        String result = jwtTokenProvider.findSubject(accessToken);
+
+        // then
+        assertThat(result).isEqualTo(subject);
+    }
+
+
+
+    private Claims getClaims(String accessToken) {
+        return assertDoesNotThrow ( () ->
+            Jwts.parserBuilder()
+                .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                .build()
+                .parseClaimsJws(accessToken)
+                .getBody()
+        );
+    }
+}

--- a/src/test/java/numble/instagram/spring/api/member/controller/MemberControllerTest.java
+++ b/src/test/java/numble/instagram/spring/api/member/controller/MemberControllerTest.java
@@ -7,7 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import numble.instagram.api.member.controller.MemberController;
 import numble.instagram.api.member.controller.request.MemberJoinRequest;
-import numble.instagram.api.member.service.mapper.MemberService;
+import numble.instagram.api.member.service.MemberService;
 import numble.instagram.spring.ControllerTestSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/numble/instagram/spring/api/member/service/MemberServiceTest.java
+++ b/src/test/java/numble/instagram/spring/api/member/service/MemberServiceTest.java
@@ -6,7 +6,7 @@ import static org.mockito.BDDMockito.given;
 
 import java.util.Optional;
 import numble.instagram.api.member.controller.request.MemberJoinRequest;
-import numble.instagram.api.member.service.mapper.MemberService;
+import numble.instagram.api.member.service.MemberService;
 import numble.instagram.domain.member.MemberRepository;
 import numble.instagram.domain.memberprofile.MemberProfileRepository;
 import org.junit.jupiter.api.AfterEach;

--- a/src/test/java/numble/instagram/spring/domain/auth/vo/EncryptedTokenTest.java
+++ b/src/test/java/numble/instagram/spring/domain/auth/vo/EncryptedTokenTest.java
@@ -1,0 +1,20 @@
+package numble.instagram.spring.domain.auth.vo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import numble.instagram.domain.auth.EncryptedToken;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class EncryptedTokenTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"test", "test2", "1234", "tokentoken"})
+    @DisplayName("토큰 암호화에 성공한다.")
+    void encryptToken(String rawToken) {
+        EncryptedToken encryptedToken = new EncryptedToken(rawToken);
+
+        assertThat(encryptedToken.getValue()).isNotEqualTo(rawToken);
+    }
+}

--- a/src/test/java/numble/instagram/spring/persistance/auth/RefreshTokenRepositoryTest.java
+++ b/src/test/java/numble/instagram/spring/persistance/auth/RefreshTokenRepositoryTest.java
@@ -1,0 +1,100 @@
+package numble.instagram.spring.persistance.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import numble.instagram.domain.auth.EncryptedToken;
+import numble.instagram.domain.auth.RefreshToken;
+import numble.instagram.domain.auth.RefreshTokenRepository;
+import numble.instagram.domain.member.GenderType;
+import numble.instagram.domain.member.Member;
+import numble.instagram.domain.member.MemberRepository;
+import numble.instagram.domain.member.vo.EncodedPassword;
+import numble.instagram.domain.member.vo.Identifier;
+import numble.instagram.domain.member.vo.Password;
+import numble.instagram.domain.memberprofile.MemberProfile;
+import numble.instagram.spring.persistance.RepositoryTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@RepositoryTest
+public class RefreshTokenRepositoryTest{
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @DisplayName("정상적으로 취소되지 않은 리프레시 토큰을 찾는다.")
+    @Test
+    void findByTokenAndIsRevokedFalse() {
+        // given
+        MemberProfile memberProfile = createMemberProfile(
+            "test@gmail.com",
+            "insta",
+            "nickname",
+            GenderType.MAN,
+            "010-1234-5678"
+        );
+
+        Member member = createMember(
+            new Identifier("identifier1"),
+            new Password("password1"),
+            memberProfile
+        );
+
+        EncryptedToken encryptedToken = new EncryptedToken("refreshToken");
+        LocalDateTime now = LocalDateTime.now();
+
+        RefreshToken refreshToken = new RefreshToken(encryptedToken, now, member);
+
+        memberRepository.save(member);
+        refreshTokenRepository.save(refreshToken);
+
+        // when
+        Optional<RefreshToken> optionalRefreshToken = refreshTokenRepository.findByTokenAndIsRevokedFalse(encryptedToken);
+
+        // then
+        assertThat(optionalRefreshToken).isNotEmpty();
+
+        RefreshToken result = optionalRefreshToken.get();
+
+        assertThat(result.getToken()).usingRecursiveComparison()
+            .isEqualTo(encryptedToken);
+    }
+
+    private MemberProfile createMemberProfile(
+        String email,
+        String nickname,
+        String name,
+        GenderType genderType,
+        String phoneNumber
+    ) {
+
+        return MemberProfile.builder()
+            .email(email)
+            .nickname(nickname)
+            .name(name)
+            .genderType(genderType)
+            .phoneNumber(phoneNumber)
+            .build();
+    }
+
+    private Member createMember(
+        Identifier identifier,
+        Password password,
+        MemberProfile memberProfile
+    ) {
+
+        EncodedPassword encodedPassword = new EncodedPassword(password);
+
+        return Member.builder()
+            .identifier(identifier)
+            .password(encodedPassword)
+            .memberProfile(memberProfile)
+            .build();
+    }
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
feat: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #8 #9 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->

* 로그인 기능 : 로그인 시, refreshToken과 accessToken을 발급하도록 했습니다.

* 인가 기능 : 인증된 사용자만 사용할 수 있는 api에 @Authenticated이 있으면 Authorization 헤더에 있는 토큰 값을 검증하여 인가 처리 하도록 구현 했습니다.

* 테스트는 구현 중에 있습니다. (오늘 중으로 마무리 예정!)